### PR TITLE
Fix bug in GenCC submission script

### DIFF
--- a/scripts/submission/submit_to_gencc.py
+++ b/scripts/submission/submit_to_gencc.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import subprocess
 import argparse
 import os
 import sys
@@ -35,8 +34,9 @@ confidence_category = {
 
 
 def fetch_g2p_records(data: dict[str, Any]) -> requests.Response:
-    """Fetches the G2P record using all the panels download
-    User is not authenticated to ensure only visible panels is downloaded
+    """
+    Fetches the G2P record using all the panels download
+    User is not authenticated to ensure only visible panels are downloaded
 
     Args:
         data (dict[str, Any]): The DB and API configuration dictionary
@@ -44,7 +44,6 @@ def fetch_g2p_records(data: dict[str, Any]) -> requests.Response:
     Returns:
         requests.Response: The response object from the get request
     """
-
     fetch_g2p_records = "panel/all/download/"
 
     url = data["api_url"] + fetch_g2p_records
@@ -58,7 +57,8 @@ def fetch_g2p_records(data: dict[str, Any]) -> requests.Response:
 
 
 def reading_data(response: requests.Response) -> list:
-    """Reads the data from the response and converts it to a csv.DictReader
+    """
+    Reads the data from the response and converts it to a csv.DictReader
 
     Args:
         response (requests.Response): The response object from the get request
@@ -66,7 +66,6 @@ def reading_data(response: requests.Response) -> list:
     Returns:
         list: The list reader
     """
-
     csv_content = io.StringIO(response.content.decode("utf-8"))
     reader = csv.DictReader(csv_content)
 
@@ -90,7 +89,7 @@ def get_unsubmitted_record(data: dict[str, Any]) -> list:
         unsubmitted = json.loads(response.content)
         return unsubmitted
     else:
-        print("Could not fetch unsubmitted records")
+        sys.exit("Could not fetch unsubmitted records from API")
 
 
 def get_later_review_date(data: dict[str, Any]) -> list:
@@ -110,22 +109,7 @@ def get_later_review_date(data: dict[str, Any]) -> list:
         later_date = json.loads(response.content)
         return later_date["ids"]
     else:
-        print("Could not fetch later review date")
-
-
-def retrieve_unsubmitted_records(data: list[dict[str, Any]], unsubmitted: list) -> list:
-    """Retrieves unsubmitted records from the read data from the file
-
-    Args:
-        data (dict[str, Any]): Content of the CSV file
-        unsubmitted (list): List of unsubmitted ids
-
-    Returns:
-        list: List of the records that have not been submitted
-    """
-    records = [row for row in data if row["g2p id"] in unsubmitted]
-
-    return records
+        sys.exit("Could not fetch later review date from API")
 
 
 def get_stable_id_associated_with_the_submission(
@@ -150,7 +134,9 @@ def get_stable_id_associated_with_the_submission(
         stable_id = json.loads(response.content)
         return stable_id[0]
     else:
-        print("Could not get stable id associated with this submission")
+        sys.exit(
+            f"Could not get the G2P stable ID associated with submission {submission_id}"
+        )
 
 
 def read_from_old_gencc_submission(file: str) -> list:
@@ -215,105 +201,76 @@ def compare_data_changes(
             new_row["update"] = 1
             updated_data.append(new_row)
 
-
     return updated_data
 
 
-def create_gencc_submission_record(
-    submission_id: str, date: str, type_of: str, stable_id: str
-):
-    """Creates the GenCC submission record by creating the record in the gencc_submission table of the DB
+def post_gencc_submission(list_of_data: list, db_config: dict[str, Any]):
+    """
+    Calls the G2P API to write to the db which records are going to be submitted to GenCC.
 
     Args:
-        submission_id (str): Submission id
-        date (str): date
-        type_of (str): Usually create
-        stable_id (str): G2P stable id
-    """
-    create_info = {
-        "submission_id": submission_id,
-        "date_of_submission": date,
-        "type_of_submission": type_of,
-        "g2p_stable_id": stable_id,
-    }
-
-    return create_info
-
-
-def post_gencc_submission(list_of_data: list, data: dict[str, Any]):
-    """Create GenCC submission record, using bulk create
-
-    Args:
-        list_of_data (list): _description_
-        data (dict[str, Any]): _description_
+        list_of_data (list): list of records to write to the db
+        db_config (dict[str, Any]): dictionary with the database connection details and the API URL
 
     """
-
     create_url = "gencc_create/"
-
     login_url = "login/"
 
-    login_info = {"username": data["username"], "password": data["api_password"]}
+    login_info = {
+        "username": db_config["username"],
+        "password": db_config["api_password"],
+    }
 
-    response = requests.post(data["api_url"] + login_url, json=login_info)
+    response = requests.post(db_config["api_url"] + login_url, json=login_info)
     if response.status_code == 200:
         try:
             response_create = requests.post(
-                data["api_url"] + create_url,
+                db_config["api_url"] + create_url,
                 json=list_of_data,
                 cookies=response.cookies,
             )
             if response_create.status_code in (200, 201):
                 print(f"GenCC submission for the records was created successfully")
             else:
-                print(
+                sys.exit(
                     f"Issues creating the submissions {response_create.status_code} {response_create.json}"
                 )
         except Exception as e:
-            print("Error:", e)
-
-
-def add_unsubmitted_ids_and_later_review_date(updated_data: list, data: list) -> list:
-    """Merging data
-
-    Args:
-        updated_data (list): Updated data from later review date checks
-        data (list): Unsubmitted ids data
-
-    Returns:
-        list: Merged list of both of them
-    """
-    return updated_data + data
-
+            sys.exit("Error:", e)
 
 
 def write_to_the_GenCC_file(
-    data: list, outfile: str, dry: str, type_of: str = None
+    data: list, outfile: str, write_to_db: bool, type_of: str = None
 ) -> str:
-    """Creates the G2P_GenCC.txt and also calls the create the gencc_submission function when dry is False,
-    A real run
-    Also writes out records with no disease id
+    """
+    Write the records to be submitted to the output file 'G2P_GenCC.txt'.
+    Records without disease id are excluded from the submission and written
+    to file 'record_with_issues.txt'.
 
     Args:
         data (dict[str, Any]): Record of unsubmitted ids
         outfile (str): Txt file to be created
-        dry (str): To allow for a real run, which updates the db
-        type_of(str): It is always set to None.
+        write_to_db (bool): Writes submission details to the db (table 'gencc_submission')
+        type_of (str): If not provided, it is set to None
 
     Returns:
-        str: An output file
+        outfile (str): The output file with records to be submitted
+        gencc_list (list): list of records to write to the db
     """
     with open(outfile, mode="w") as output_file:
         output_file.write(
-            "submission_id\thgnc_id\thgnc_symbol\tdisease_id\tdisease_name\tmoi_id\tmoi_name\tsubmitter_id\tsubmitter_name\tclassification_id\tclassification_name\tdate\tpublic_report_url\tpmids\tassertion_criteria_url\n"
+            "submission_id\thgnc_id\thgnc_symbol\tdisease_id\tdisease_name\tmoi_id\tmoi_name\tsubmitter_id\tsubmitter_name\tclassification_id\tclassification_name\tdate\tpublic_report_url\tnotes\tpmids\tassertion_criteria_url\n"
         )
         issues_with_record = []
         gencc_list = []
         submission_id_base = "1000112"
         for record in data:
-            print(record, "\n")
             g2p_id = record["g2p id"]
-            submission_id = submission_id_base + str(g2p_id[3:]) if not record.get("submission_id") else record.get("submission_id")
+            submission_id = (
+                submission_id_base + str(g2p_id[3:])
+                if not record.get("submission_id")
+                else record.get("submission_id")
+            )
 
             hgnc_id = record["hgnc id"]
             hgnc_symbol = record["gene symbol"]
@@ -326,26 +283,32 @@ def write_to_the_GenCC_file(
             moi_id = allelic_requirement[record["allelic requirement"]]
             moi_name = record["allelic requirement"]
             submitter_id = "GENCC:000112"
-            submitter_name = "TGMI"
+            submitter_name = "TGMI"  # To be updated in the future
             classification_id = confidence_category[record["confidence"]]
             classification_name = record["confidence"]
             dt = datetime.fromisoformat(record["date of last review"])
             date = dt.strftime("%Y/%m/%d")
             record_url = "https://www.ebi.ac.uk/gene2phenotype/lgd/" + g2p_id
             pmids = record["publications"]
-            assertion_criteria_url = "https://www.ebi.ac.uk/gene2phenotype/terminology"
+            assertion_criteria_url = (
+                "https://www.ebi.ac.uk/gene2phenotype/about/terminology"
+            )
 
-            line_to_output = f"{submission_id}\t{hgnc_id}\t{hgnc_symbol}\t{disease_id}\t{disease_name}\t{moi_id}\t{moi_name}\t{submitter_id}\t{submitter_name}\t{classification_id}\t{classification_name}\t{date}\t{record_url}\t{pmids}\t{assertion_criteria_url}\n"
+            line_to_output = f"{submission_id}\t{hgnc_id}\t{hgnc_symbol}\t{disease_id}\t{disease_name}\t{moi_id}\t{moi_name}\t{submitter_id}\t{submitter_name}\t{classification_id}\t{classification_name}\t{date}\t{record_url}\t\t{pmids}\t{assertion_criteria_url}\n"
             output_file.write(line_to_output)
             db_date = create_datetime_now()
-            if dry:
-                type_of = None
+            if write_to_db:
                 if not type_of:
+                    # TODO: fix bug
                     type_of = "update" if record.get("update") == 1 else "create"
-                created_record = create_gencc_submission_record(
-                    submission_id, db_date, type_of, g2p_id
+                gencc_list.append(
+                    {
+                        "submission_id": submission_id,
+                        "date_of_submission": db_date,
+                        "type_of_submission": type_of,
+                        "g2p_stable_id": g2p_id,
+                    }
                 )
-                gencc_list.append(created_record)
     if len(issues_with_record) > 0:
         with open("record_with_issues.txt", mode="w") as textfile:
             for issues in issues_with_record:
@@ -409,14 +372,15 @@ def read_from_config_file(config_file: str) -> dict[str, Any]:
     return data
 
 
-def get_output_paths(path: str) -> Tuple[str, str, str]:
-    """Gets the output path from the args.path
+def get_output_paths(path: str) -> Tuple[str, str]:
+    """
+    Create the output directory and prepare the output file path.
 
     Args:
-        path (str): The path (args.path)
+        path (str): path where the G2P and GenCC files are going to be saved
 
     Returns:
-        Tuple[str, str, str]: Gencc dir (args.path if given), output file and final_output_file
+        Tuple[str, str]: output file (txt format) and final_output_file (xlsx format)
     """
     if path:
         timestamp = create_datetime_now()
@@ -425,35 +389,18 @@ def get_output_paths(path: str) -> Tuple[str, str, str]:
 
         output_file = os.path.join(gencc_dir, "G2P_GenCC.txt")
         final_output_file = os.path.join(gencc_dir, "G2P_GenCC.xlsx")
-        return gencc_dir, output_file, final_output_file
     else:
+        # TODO: this should create the new directory too
         output_file = "G2P_GenCC.txt"
         final_output_file = "G2P_GenCC.xlsx"
-        return ".", output_file, final_output_file
 
-
-def handle_new_submission(
-    read_data: list, output_file: str, dry: bool, db_config: dict[str, Any]
-) -> write_to_the_GenCC_file:
-    """Handles new submission, so new generation of the G2P records and GenCC data
-
-    Args:
-        read_data (list): Data from the G2P all records file
-        output_file (str): Output text file where the submission will be written into
-        dry (bool): Boolean (args.dry)
-        db_config (dict[str, Any]): DB/API configuration
-
-    Returns:
-        write_to_the_GenCC_file: A text file containing all the records to be submitted to GenCC
-    """
-    type_of = "create"
-    return write_to_the_GenCC_file(read_data, output_file, dry, db_config, type_of)
+    return output_file, final_output_file
 
 
 def handle_existing_submission(
     read_data: list,
     output_file: str,
-    dry: bool,
+    write_to_db: bool,
     db_config: dict[str, Any],
     old_file: str,
 ) -> write_to_the_GenCC_file:
@@ -462,7 +409,7 @@ def handle_existing_submission(
     Args:
         read_data (list): Data from the G2P all records file
         output_file (str): Output text file where the submission will be written into
-        dry (bool): Boolean (args.dry)
+        write_to_db (bool): If set to True, write submission details to the db
         db_config (dict[str, Any]): DB/API configuration
         old_file (str) : Old file containing submitted GenCC submission to allow comparison
 
@@ -470,17 +417,17 @@ def handle_existing_submission(
         write_to_the_GenCC_file: A text file containing all the records to be submitted to GenCC
     """
     unsubmitted = get_unsubmitted_record(db_config)
-    common = retrieve_unsubmitted_records(read_data, unsubmitted)
+    # Retrieves unsubmitted records from the data from the file
+    common = [row for row in read_data if row["g2p id"] in unsubmitted]
 
     if old_file:
         old_reader = read_from_old_gencc_submission(old_file)
         later_review = get_later_review_date(db_config)
         compared = compare_data_changes(old_reader, later_review, read_data, db_config)
-        merged_data = add_unsubmitted_ids_and_later_review_date(compared, common)
-        return write_to_the_GenCC_file(merged_data, output_file, dry)
+        merged_data = compared + common
+        return write_to_the_GenCC_file(merged_data, output_file, write_to_db)
     else:
-        type_of = "create"
-        return write_to_the_GenCC_file(common, output_file, dry, type_of)
+        return write_to_the_GenCC_file(common, output_file, write_to_db, "create")
 
 
 def main():
@@ -514,32 +461,36 @@ def main():
         ap.error("Cannot use --new and --old_file at the same time.")
 
     db_config = read_from_config_file(args.config_file)
-    dry_run = args.write_to_db
+    write_to_db = args.write_to_db
+    old_file = args.old_file
 
-    gencc_dir, output_file, final_output_file = get_output_paths(args.path)
+    if old_file and not os.path.isfile(old_file):
+        sys.exit(f"Invalid file '{old_file}'")
 
-    print("Downloading G2P files...")
+    output_file, final_output_file = get_output_paths(args.path)
+
+    print("Downloading G2P files")
     file_data = fetch_g2p_records(db_config)
+
     print("Reading data from downloaded file")
     read_data = reading_data(file_data)
 
     if args.new:
         print("Handling new submission")
-        outfile, gencc_list = handle_new_submission(
-            read_data, output_file, dry_run, db_config
+        outfile, gencc_list = write_to_the_GenCC_file(
+            read_data, output_file, write_to_db, "create"
         )
     else:
         print("Handling existing submission")
-        old_file = args.old_file
         outfile, gencc_list = handle_existing_submission(
-            read_data, output_file, dry_run, db_config, old_file
+            read_data, output_file, write_to_db, db_config, old_file
         )
 
     print("Converting text file to Excel file")
     convert_txt_to_excel(outfile, final_output_file)
 
-    if args.write_to_db:
-        print("Writing submission to the database")
+    if write_to_db:
+        print("Writing submission details to the database")
         post_gencc_submission(gencc_list, db_config)
 
 


### PR DESCRIPTION
- Fix bug when calling `write_to_the_GenCC_file`
- Remove unnecessary methods - call them directly
- Format file with Ruff

There is still on bug in `write_to_the_GenCC_file`. When running the script with the old file, the new records are being saved in the db as `type_of_submission = update`. I created a ticket to fix this before we re-submit records.